### PR TITLE
perf(pencil): remove graphiteWidth option

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -13,3 +13,4 @@ const config = {
 };
 
 module.exports = config;
+


### PR DESCRIPTION
BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reasons.

---
name: Pull Request
about: Create a report to help us improve
title: ''
labels: ''
assignees: ''

---

## Description
Please explain the changes you made here and link to any relevant issues.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules